### PR TITLE
Add blacklist of IPv6-breaking functions

### DIFF
--- a/rpminspect.conf
+++ b/rpminspect.conf
@@ -61,6 +61,11 @@ buildhost_subdomain = ".fedoraproject.org .bos.redhat.com"
 elf_path_include = ""
 elf_path_exclude = "(^(/boot/vmlinu|/lib/modules|/lib64/modules).*)|(.*/powerpc/lib/crtsavres.o$)|(^/usr/lib(64)?/kernel-wrapper$)"
 
+# Blacklist of functions which indicate broken support for IPv6. Depending
+# on how they are used, their usage could be benign but it requires manual
+# inspection.
+elf_ipv6_blacklist = "gethostbyname gethostbyname2 gethostbyaddr inet_addr inet_aton inet_nsap_addr inet_ntoa inet_nsap_ntoa inet_makeaddr inet_netof inet_network inet_neta inet_net_ntop inet_net_pton rcmd rexec rresvport"
+
 manpage_path_include = "^/usr/share/man/.*"
 manpage_path_exclude = ""
 


### PR DESCRIPTION
These functions don't support IPv6; their use may indicate partial or
broken IPv6 support.

Sourced from http://www.akkadia.org/drepper/userapi-ipv6.html

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`