### PR TITLE
Change bytecode version to be JDK 8

### DIFF
--- a/rpminspect.conf
+++ b/rpminspect.conf
@@ -139,7 +139,7 @@ shells = "sh ksh zsh csh tcsh rc bash"
 # should be the product release string that you will use consistently
 # throughout the run of rpminspect (e.g., a dist tag for Fedora).  The
 # value is the JVM major version.  For example:
-#     fc30 = 53
+#     fc30 = 52
 # You should also always specify a default, like this:
 #     default = 43
 # If the product release string is not found, the javabytecode test will
@@ -147,5 +147,9 @@ shells = "sh ksh zsh csh tcsh rc bash"
 # this section.  Default is 43 because that was the first JVM major
 # version in the .class file format.
 [javabytecode]
-fc30 = 53
+fc28 = 52
+fc29 = 52
+fc30 = 52
+fc31 = 52
+fc32 = 52
 default = 43


### PR DESCRIPTION
Fedora 28 through current Rawhide (F32) ship with OpenJDK 8 as the
default JDK version. JDK 9 isn't shipped, though JDK 11 is.

Setting the bytecode version to having a target version of JDK 9
doesn't make sense. This changes the Fedora-specific versions to 52
(JDK 8's major version number) for Fedora 28 through current Rawhide.

See: https://www.oracle.com/technetwork/java/javase/8-compatibility-guide-2156366.html
    Heading: Java Class Files

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----- 


In the (unlikely?) event JDK 8 is dropped from F32, we'll need to update this accordingly. However, currently the LTS JDK, JDK 13, [isn't packaged](https://src.fedoraproject.org/rpms/java-13-openjdk) so I'd find it surprising if this change will be proposed.