### PR TITLE
Add Fedora 32 to stat-whitelist, F33 will have Java 11

### DIFF
--- a/rpminspect.conf
+++ b/rpminspect.conf
@@ -247,6 +247,7 @@ fc29 = 52
 fc30 = 52
 fc31 = 52
 fc32 = 52
+fc33 = 55
 default = 43
 
 # Path migrations.  Over time the established best practices or

--- a/stat-whitelist/f29
+++ b/stat-whitelist/f29
@@ -1,4 +1,4 @@
-# Fedora rawhide setuid whitelist
+# Fedora 29 setuid whitelist
 
 #
 # setuid verification list.  All files installed with setuid or setgid permissions must be listed here with the expected permissions (st_mode), expected owner, and expected group.  Blank lines and lines beginning with '#' are ignored.

--- a/stat-whitelist/f30
+++ b/stat-whitelist/f30
@@ -1,4 +1,4 @@
-# Fedora rawhide setuid whitelist
+# Fedora 30 setuid whitelist
 
 #
 # setuid verification list.  All files installed with setuid or setgid permissions must be listed here with the expected permissions (st_mode), expected owner, and expected group.  Blank lines and lines beginning with '#' are ignored.

--- a/stat-whitelist/f32
+++ b/stat-whitelist/f32
@@ -1,4 +1,4 @@
-# Fedora 31 setuid whitelist
+# Fedora 32 setuid whitelist
 
 #
 # setuid verification list.  All files installed with setuid or setgid permissions must be listed here with the expected permissions (st_mode), expected owner, and expected group.  Blank lines and lines beginning with '#' are ignored.


### PR DESCRIPTION
Two commits in this PR:

 - Add Fedora 32 to stat-whitelist directory, clarify the version names inside the files
 - Fedora 33 will have [Java 11 as the default](https://fedoraproject.org/wiki/Changes/Java11), moving up from previous versions with JDK 8. Update the byte [code version appropriately](https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html).