### PR TITLE
Add /usr/bin/vmware-user-suid-wrapper to setxid whitelist

### DIFF
--- a/stat-whitelist/f30
+++ b/stat-whitelist/f30
@@ -88,3 +88,4 @@ drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
 -rwsr-x---          root       sssd       /usr/libexec/sssd/krb5_child
 -rwsr-x---          root       sssd       /usr/libexec/sssd/ldap_child
 -rwsr-x---          root       sssd       /usr/libexec/sssd/proxy_child
+-rwsr-xr-x          root       root       /usr/bin/vmware-user-suid-wrapper

--- a/stat-whitelist/f31
+++ b/stat-whitelist/f31
@@ -88,3 +88,4 @@ drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
 -rwsr-x---          root       sssd       /usr/libexec/sssd/krb5_child
 -rwsr-x---          root       sssd       /usr/libexec/sssd/ldap_child
 -rwsr-x---          root       sssd       /usr/libexec/sssd/proxy_child
+-rwsr-xr-x          root       root       /usr/bin/vmware-user-suid-wrapper

--- a/stat-whitelist/f32
+++ b/stat-whitelist/f32
@@ -88,3 +88,4 @@ drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
 -rwsr-x---          root       sssd       /usr/libexec/sssd/krb5_child
 -rwsr-x---          root       sssd       /usr/libexec/sssd/ldap_child
 -rwsr-x---          root       sssd       /usr/libexec/sssd/proxy_child
+-rwsr-xr-x          root       root       /usr/bin/vmware-user-suid-wrapper

--- a/stat-whitelist/rawhide
+++ b/stat-whitelist/rawhide
@@ -88,3 +88,4 @@ drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
 -rwsr-x---          root       sssd       /usr/libexec/sssd/krb5_child
 -rwsr-x---          root       sssd       /usr/libexec/sssd/ldap_child
 -rwsr-x---          root       sssd       /usr/libexec/sssd/proxy_child
+-rwsr-xr-x          root       root       /usr/bin/vmware-user-suid-wrapper


### PR DESCRIPTION
With rebase of open-vm-tools new suid wrapper was introduced. Adding it
to whitelist.