### PR TITLE
add new license: AHFL

### DIFF
--- a/licenses/fedora.json
+++ b/licenses/fedora.json
@@ -6726,4 +6726,14 @@
      "spdx_name": "MIT No Attribution License",
      "url": "https://spdx.org/licenses/MIT-0.html"
   },
+  "Atkinson Hyperlegible Font License": {
+    "approved": "yes",
+    "fedora_abbrev": "AHFL",
+    "fedora_name": "Atkinson Hyperlegible Font License",
+    "id": "671",
+    "license_text": "",
+    "spdx_abbrev": "",
+    "spdx_name": "",
+    "url": "https://www.brailleinstitute.org/wp-content/uploads/2020/11/Atkinson-Hyperlegible-Font-License-2020-1104.pdf"
+  },
 }


### PR DESCRIPTION
There was one new license introduced in TeXLive 2021: The Atkinson Hyperlegible Font License. It was reviewed on legal@lists.fedoraproject.org, determined to be acceptable, and added to the Fedora Licensing "Good Font Licenses" list.