### PR TITLE
Bump version to 1.6

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('rpminspect-data-fedora',
-        version : '1.5',
+        version : '1.6',
         license : 'CC-BY-SA-4.0',
         meson_version : '>=0.47.0')
 


### PR DESCRIPTION
1.5-2 has been released already, but copr builds have following version-release: 1.5-0.1.202108061506git.fc34, i.e. rpm thinks that they are older than what's already in the main repositories.