### PR TITLE
Add expected bytecode version for f36

### DIFF
--- a/fedora.yaml
+++ b/fedora.yaml
@@ -505,6 +505,7 @@ javabytecode:
     - fc33: 55
     - fc34: 55
     - fc35: 55
+    - fc36: 55  
     - default: 43
 
     # Optional list of glob(7) specifications to match files to ignore


### PR DESCRIPTION
See: https://pagure.io/fedora-ci/general/issue/268.