### PR TITLE
new*idmap: change permissions

### DIFF
--- a/fileinfo/fc33
+++ b/fileinfo/fc33
@@ -84,8 +84,6 @@ drwxrwsr-x          root       mailman    /var/lib/mailman/spam
 -rws--x--x          root       root       /usr/bin/chsh
 drwxrwsr-x          uuidd      uuidd      /run/uuidd
 drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
--rwsr-xr-x          root       root       /usr/bin/newuidmap
--rwsr-xr-x          root       root       /usr/bin/newgidmap
 -rwsr-sr-x          tlog       tlog       /usr/bin/tlog-rec-session
 -rwsr-xr-x          root       root       /usr/sbin/grub2-set-bootflag
 -rwsr-x---          root       sssd       /usr/libexec/sssd/selinux_child

--- a/fileinfo/fc34
+++ b/fileinfo/fc34
@@ -84,8 +84,6 @@ drwxrwsr-x          root       mailman    /var/lib/mailman/spam
 -rws--x--x          root       root       /usr/bin/chsh
 drwxrwsr-x          uuidd      uuidd      /run/uuidd
 drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
--rwsr-xr-x          root       root       /usr/bin/newuidmap
--rwsr-xr-x          root       root       /usr/bin/newgidmap
 -rwsr-sr-x          tlog       tlog       /usr/bin/tlog-rec-session
 -rwsr-xr-x          root       root       /usr/sbin/grub2-set-bootflag
 -rwsr-x---          root       sssd       /usr/libexec/sssd/selinux_child

--- a/fileinfo/fc35
+++ b/fileinfo/fc35
@@ -84,8 +84,6 @@ drwxrwsr-x          root       mailman    /var/lib/mailman/spam
 -rws--x--x          root       root       /usr/bin/chsh
 drwxrwsr-x          uuidd      uuidd      /run/uuidd
 drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
--rwsr-xr-x          root       root       /usr/bin/newuidmap
--rwsr-xr-x          root       root       /usr/bin/newgidmap
 -rwsr-sr-x          tlog       tlog       /usr/bin/tlog-rec-session
 -rwsr-xr-x          root       root       /usr/sbin/grub2-set-bootflag
 -rwsr-x---          root       sssd       /usr/libexec/sssd/selinux_child

--- a/fileinfo/fc36
+++ b/fileinfo/fc36
@@ -84,8 +84,6 @@ drwxrwsr-x          root       mailman    /var/lib/mailman/spam
 -rws--x--x          root       root       /usr/bin/chsh
 drwxrwsr-x          uuidd      uuidd      /run/uuidd
 drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
--rwsr-xr-x          root       root       /usr/bin/newuidmap
--rwsr-xr-x          root       root       /usr/bin/newgidmap
 -rwsr-sr-x          tlog       tlog       /usr/bin/tlog-rec-session
 -rwsr-xr-x          root       root       /usr/sbin/grub2-set-bootflag
 -rwsr-x---          root       sssd       /usr/libexec/sssd/selinux_child


### PR DESCRIPTION
cap_setxid file capabilities are used instead of making them setuid.

Capabilities are already checked. Example: https://github.com/rpminspect/rpminspect-data-fedora/blob/master/capabilities/fc33#L36