### PR TITLE
Remove setuid permission for an ABRT binary

### DIFF
--- a/fileinfo/fc35
+++ b/fileinfo/fc35
@@ -11,7 +11,7 @@
 #-rwsr-xr-x    root    root     /usr/bin/mount
 #
 #<symbolic mode>    <owner>    <group>    <file path>
--rwsr-sr-x          abrt       abrt       /usr/libexec/abrt-action-install-debuginfo-to-abrt-cache
+-rwxr-sr-x          abrt       abrt       /usr/libexec/abrt-action-install-debuginfo-to-abrt-cache
 -rwsr-x---          root       disk       /usr/lib64/amanda/application/amgtar
 -rwsr-x---          root       disk       /usr/lib64/amanda/application/amstar
 -rwsr-x---          root       disk       /usr/lib64/amanda/calcsize

--- a/fileinfo/fc36
+++ b/fileinfo/fc36
@@ -11,7 +11,7 @@
 #-rwsr-xr-x    root    root     /usr/bin/mount
 #
 #<symbolic mode>    <owner>    <group>    <file path>
--rwsr-sr-x          abrt       abrt       /usr/libexec/abrt-action-install-debuginfo-to-abrt-cache
+-rwxr-sr-x          abrt       abrt       /usr/libexec/abrt-action-install-debuginfo-to-abrt-cache
 -rwsr-x---          root       disk       /usr/lib64/amanda/application/amgtar
 -rwsr-x---          root       disk       /usr/lib64/amanda/application/amstar
 -rwsr-x---          root       disk       /usr/lib64/amanda/calcsize


### PR DESCRIPTION
The abrt-action-install-debuginfo-to-abrt-cache binary should no longer have the setuid flag. The flag has been removed in abrt version 2.14.3 (August 2020). See abrt/abrt#1485 for details.