### PR TITLE
Update security rule files instructions

### DIFF
--- a/security/fc36
+++ b/security/fc36
@@ -3,14 +3,26 @@
 #
 # One package per line.  Blank lines and lines beginning with '#' are
 # ignored.  Malformed lines are ignored, but a warning is displayed.
-# Each rule consists of four fields separated by spaces or tabs (any
+# The first matching rule in this file is used by rpminspect, so be
+# careful of ordering of explicit files and packages and then wildcard
+# rules.
+#
+# Each rule consists of five fields separated by spaces or tabs (any
 # number):
 #
-#     name           The name of the package
+#     path           The file or path, can use glob(7) syntax
+#     name           The name of the package, can use glob(7) syntax
 #     version        The package version, can use glob(7) syntax
 #     release        The package release, can use glob(7) syntax
 #     rules          Comma-delimited list of security rules where each
 #                    element is RULE=ACTION.
+#
+# It is common to establish per-file rules in a specific package, but
+# with glob(7) syntax it is possible to write a rule that applies to
+# all files in a package.  Just be aware of what you are writing in
+# the fields because security rules should favor more explicit
+# matching over wildcard matching.  The most common fields to carry
+# '*' values should be version and release.
 #
 # Available RULES (case-insensitive in the config file):
 #
@@ -38,3 +50,5 @@
 #     FAIL           The finding is reported at the BAD level, which does
 #                    trigger a failing exit code.
 #
+
+#<path>           <package>   <version>   <release>   <rules>

--- a/security/fc37
+++ b/security/fc37
@@ -3,14 +3,26 @@
 #
 # One package per line.  Blank lines and lines beginning with '#' are
 # ignored.  Malformed lines are ignored, but a warning is displayed.
-# Each rule consists of four fields separated by spaces or tabs (any
+# The first matching rule in this file is used by rpminspect, so be
+# careful of ordering of explicit files and packages and then wildcard
+# rules.
+#
+# Each rule consists of five fields separated by spaces or tabs (any
 # number):
 #
-#     name           The name of the package
+#     path           The file or path, can use glob(7) syntax
+#     name           The name of the package, can use glob(7) syntax
 #     version        The package version, can use glob(7) syntax
 #     release        The package release, can use glob(7) syntax
 #     rules          Comma-delimited list of security rules where each
 #                    element is RULE=ACTION.
+#
+# It is common to establish per-file rules in a specific package, but
+# with glob(7) syntax it is possible to write a rule that applies to
+# all files in a package.  Just be aware of what you are writing in
+# the fields because security rules should favor more explicit
+# matching over wildcard matching.  The most common fields to carry
+# '*' values should be version and release.
 #
 # Available RULES (case-insensitive in the config file):
 #
@@ -38,3 +50,5 @@
 #     FAIL           The finding is reported at the BAD level, which does
 #                    trigger a failing exit code.
 #
+
+#<path>           <package>   <version>   <release>   <rules>

--- a/security/fc38
+++ b/security/fc38
@@ -3,14 +3,26 @@
 #
 # One package per line.  Blank lines and lines beginning with '#' are
 # ignored.  Malformed lines are ignored, but a warning is displayed.
-# Each rule consists of four fields separated by spaces or tabs (any
+# The first matching rule in this file is used by rpminspect, so be
+# careful of ordering of explicit files and packages and then wildcard
+# rules.
+#
+# Each rule consists of five fields separated by spaces or tabs (any
 # number):
 #
-#     name           The name of the package
+#     path           The file or path, can use glob(7) syntax
+#     name           The name of the package, can use glob(7) syntax
 #     version        The package version, can use glob(7) syntax
 #     release        The package release, can use glob(7) syntax
 #     rules          Comma-delimited list of security rules where each
 #                    element is RULE=ACTION.
+#
+# It is common to establish per-file rules in a specific package, but
+# with glob(7) syntax it is possible to write a rule that applies to
+# all files in a package.  Just be aware of what you are writing in
+# the fields because security rules should favor more explicit
+# matching over wildcard matching.  The most common fields to carry
+# '*' values should be version and release.
 #
 # Available RULES (case-insensitive in the config file):
 #
@@ -38,3 +50,5 @@
 #     FAIL           The finding is reported at the BAD level, which does
 #                    trigger a failing exit code.
 #
+
+#<path>           <package>   <version>   <release>   <rules>


### PR DESCRIPTION
Security rule format was extended some time ago to include path.  Update instructions in the Fedora security files to match the updated version in the main rpminspect sources:
https://github.com/rpminspect/rpminspect/blob/main/data/security/GENERIC

Resolves: https://github.com/rpminspect/rpminspect-data-fedora/issues/33