### PR TITLE
Uncomment start of the inspections section

### DIFF
--- a/fedora.yaml
+++ b/fedora.yaml
@@ -92,7 +92,7 @@ vendor:
     # files to use from the vendor_data_dir.
     #favor_release: newest
 
-#inspections:
+inspections:
     # By default all inspections are enabled.  You can enable and
     # disable inspections using the command line -T and -E options, or
     # you can add them to this section in the config file.  The format


### PR DESCRIPTION
There's 'kmidiff: off' listed couple of lines below to disable kmidiff inspection.  However, with the start of the inspection section commented out, that setting is ignored.

Resolves: https://github.com/rpminspect/rpminspect-data-fedora/issues/32