### PR TITLE
Add maildrop to fileinfo

### DIFF
--- a/fileinfo/fc36
+++ b/fileinfo/fc36
@@ -96,3 +96,5 @@ drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
 drwxrws---          root       ts-shell   /var/log/ts-shell
 drwxrwxrwt          root       root       /tmp
 drwxrwxrwt          root       root       /var/tmp
+-rwsr-sr-x          root       mail       /usr/bin/lockmail
+-rwsr-sr-x          root       mail       /usr/bin/maildrop

--- a/fileinfo/fc37
+++ b/fileinfo/fc37
@@ -96,3 +96,5 @@ drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
 drwxrws---          root       ts-shell   /var/log/ts-shell
 drwxrwxrwt          root       root       /tmp
 drwxrwxrwt          root       root       /var/tmp
+-rwsr-sr-x          root       mail       /usr/bin/lockmail
+-rwsr-sr-x          root       mail       /usr/bin/maildrop

--- a/fileinfo/fc38
+++ b/fileinfo/fc38
@@ -96,3 +96,5 @@ drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
 drwxrws---          root       ts-shell   /var/log/ts-shell
 drwxrwxrwt          root       root       /tmp
 drwxrwxrwt          root       root       /var/tmp
+-r-xr-xr-x          root       mail       /usr/bin/lockmail
+-r-xr-xr-x          root       mail       /usr/bin/maildrop


### PR DESCRIPTION
On fc37 and before the permissions were 06755 root:mail, in fc38 the suid and sgid bits have been dropped, but ownership left as root:mail