### PR TITLE
Exclude libpython3.so from the debuginfo tests

### DIFF
--- a/fedora.yaml
+++ b/fedora.yaml
@@ -858,6 +858,7 @@ debuginfo:
         - /lib/modules/*
         - /usr/lib/debug/.dwz/*
         - /usr/lib/grub/*
+        - /usr/lib/debug/usr/lib*/libpython3.so*
 
     # The ELF section name(s) required in debuginfo packages.  The
     # default is shown here.  Some older releases may have to change


### PR DESCRIPTION
libpython3.so doesn't contain any compiled code
and it's there to point applications to the versioned libpython library where the compiled code is. Hence we cannot strip debug symbols from there.

See also: https://bugzilla.redhat.com/show_bug.cgi?id=2144553#c16