### PR TITLE
Define directory permissions for `/var/tmp/tmt`

### DIFF
--- a/fileinfo/fc37
+++ b/fileinfo/fc37
@@ -96,5 +96,6 @@ drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
 drwxrws---          root       ts-shell   /var/log/ts-shell
 drwxrwxrwt          root       root       /tmp
 drwxrwxrwt          root       root       /var/tmp
+drwxrwxrwt          root       root       /var/tmp/tmt
 -rwsr-sr-x          root       mail       /usr/bin/lockmail
 -rwsr-sr-x          root       mail       /usr/bin/maildrop

--- a/fileinfo/fc38
+++ b/fileinfo/fc38
@@ -96,5 +96,6 @@ drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
 drwxrws---          root       ts-shell   /var/log/ts-shell
 drwxrwxrwt          root       root       /tmp
 drwxrwxrwt          root       root       /var/tmp
+drwxrwxrwt          root       root       /var/tmp/tmt
 -r-xr-xr-x          root       mail       /usr/bin/lockmail
 -r-xr-xr-x          root       mail       /usr/bin/maildrop

--- a/fileinfo/fc39
+++ b/fileinfo/fc39
@@ -96,5 +96,6 @@ drwxrwsr-x          uuidd      uuidd      /var/lib/libuuid
 drwxrws---          root       ts-shell   /var/log/ts-shell
 drwxrwxrwt          root       root       /tmp
 drwxrwxrwt          root       root       /var/tmp
+drwxrwxrwt          root       root       /var/tmp/tmt
 -r-xr-xr-x          root       mail       /usr/bin/lockmail
 -r-xr-xr-x          root       mail       /usr/bin/maildrop


### PR DESCRIPTION
This directory has intentionally `drwxrwxrwt` permissions because it is used for storing tmt run workdirs and provision images.