### PR TITLE
Allow unicode in source files for dotnet6.0 and dotnet7.0

### DIFF
--- a/security/fc37
+++ b/security/fc37
@@ -53,6 +53,17 @@
 
 #<path>           <package>   <version>   <release>   <rules>
 
+# dotnet
+# Ignore test data containing unicode codepoints
+dotnet-*/src/runtime/src/libraries/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_1?_0/IdnaTest_1?.txt dotnet*.0 * * unicode=INFORM
+# Fixed in of .NET 7 and later with https://github.com/dotnet/aspnetcore/pull/38900
+dotnet-v6.*/src/aspnetcore/src/Http/Http/src/Features/FormOptions.cs dotnet6.0 * * unicode=INFORM
+dotnet-v6.*/src/aspnetcore/src/Http/WebUtilities/src/FormReader.cs dotnet6.0 * * unicode=INFORM
+dotnet-v6.*/src/aspnetcore/src/Http/WebUtilities/src/MultipartReader.cs dotnet6.0 * * unicode=INFORM
+# Ignore API-headers (reference assembly) in .NET 7 from older versions of .NET
+dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/6.0.0/ref/net6.0/Microsoft.AspNetCore.Http.xml dotnet7.0 * * unicode=INFORM
+dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/6.0.0/ref/net6.0/Microsoft.AspNetCore.WebUtilities.xml dotnet7.0 * * unicode=INFORM
+
 # glibc localedata template files and test files
 glibc-*/localedata/cmn_TW.UTF-8.in          glibc       *       *       unicode=SKIP
 glibc-*/libio/tst-widetext.input            glibc       *       *       unicode=SKIP

--- a/security/fc38
+++ b/security/fc38
@@ -53,6 +53,17 @@
 
 #<path>           <package>   <version>   <release>   <rules>
 
+# dotnet
+# Ignore test data containing unicode codepoints
+dotnet-*/src/runtime/src/libraries/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_1?_0/IdnaTest_1?.txt dotnet*.0 * * unicode=INFORM
+# Fixed in of .NET 7 and later with https://github.com/dotnet/aspnetcore/pull/38900
+dotnet-v6.*/src/aspnetcore/src/Http/Http/src/Features/FormOptions.cs dotnet6.0 * * unicode=INFORM
+dotnet-v6.*/src/aspnetcore/src/Http/WebUtilities/src/FormReader.cs dotnet6.0 * * unicode=INFORM
+dotnet-v6.*/src/aspnetcore/src/Http/WebUtilities/src/MultipartReader.cs dotnet6.0 * * unicode=INFORM
+# Ignore API-headers (reference assembly) in .NET 7 from older versions of .NET
+dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/6.0.0/ref/net6.0/Microsoft.AspNetCore.Http.xml dotnet7.0 * * unicode=INFORM
+dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/6.0.0/ref/net6.0/Microsoft.AspNetCore.WebUtilities.xml dotnet7.0 * * unicode=INFORM
+
 # glibc localedata template files and test files
 glibc-*/localedata/cmn_TW.UTF-8.in          glibc       *       *       unicode=SKIP
 glibc-*/libio/tst-widetext.input            glibc       *       *       unicode=SKIP

--- a/security/fc39
+++ b/security/fc39
@@ -53,6 +53,17 @@
 
 #<path>           <package>   <version>   <release>   <rules>
 
+# dotnet
+# Ignore test data containing unicode codepoints
+dotnet-*/src/runtime/src/libraries/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_1?_0/IdnaTest_1?.txt dotnet*.0 * * unicode=INFORM
+# Fixed in of .NET 7 and later with https://github.com/dotnet/aspnetcore/pull/38900
+dotnet-v6.*/src/aspnetcore/src/Http/Http/src/Features/FormOptions.cs dotnet6.0 * * unicode=INFORM
+dotnet-v6.*/src/aspnetcore/src/Http/WebUtilities/src/FormReader.cs dotnet6.0 * * unicode=INFORM
+dotnet-v6.*/src/aspnetcore/src/Http/WebUtilities/src/MultipartReader.cs dotnet6.0 * * unicode=INFORM
+# Ignore API-headers (reference assembly) in .NET 7 from older versions of .NET
+dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/6.0.0/ref/net6.0/Microsoft.AspNetCore.Http.xml dotnet7.0 * * unicode=INFORM
+dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/6.0.0/ref/net6.0/Microsoft.AspNetCore.WebUtilities.xml dotnet7.0 * * unicode=INFORM
+
 # glibc localedata template files and test files
 glibc-*/localedata/cmn_TW.UTF-8.in          glibc       *       *       unicode=SKIP
 glibc-*/libio/tst-widetext.input            glibc       *       *       unicode=SKIP


### PR DESCRIPTION
Hopefully this get rids of the failing "unicode" tests that can be seen at https://artifacts.dev.testing-farm.io/5f8dd3b3-dafa-467f-854d-8f4d18d333b0/