### PR TITLE
Allow Unicode in perl-Prima documentation

### DIFF
--- a/security/fc37
+++ b/security/fc37
@@ -67,3 +67,6 @@ dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.
 # glibc localedata template files and test files
 glibc-*/localedata/cmn_TW.UTF-8.in          glibc       *       *       unicode=SKIP
 glibc-*/libio/tst-widetext.input            glibc       *       *       unicode=SKIP
+
+# perl-Prima documentation contains RTL control characters on purpose
+Prima-*/Prima/Drawable/Glyphs.pm            perl-Prima  *       *       unicode=INFORM

--- a/security/fc38
+++ b/security/fc38
@@ -67,3 +67,6 @@ dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.
 # glibc localedata template files and test files
 glibc-*/localedata/cmn_TW.UTF-8.in          glibc       *       *       unicode=SKIP
 glibc-*/libio/tst-widetext.input            glibc       *       *       unicode=SKIP
+
+# perl-Prima documentation contains RTL control characters on purpose
+Prima-*/Prima/Drawable/Glyphs.pm            perl-Prima  *       *       unicode=INFORM

--- a/security/fc39
+++ b/security/fc39
@@ -68,5 +68,8 @@ dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.
 glibc-*/localedata/cmn_TW.UTF-8.in          glibc       *       *       unicode=SKIP
 glibc-*/libio/tst-widetext.input            glibc       *       *       unicode=SKIP
 
+# perl-Prima documentation contains RTL control characters on purpose
+Prima-*/Prima/Drawable/Glyphs.pm            perl-Prima  *       *       unicode=INFORM
+
 # systemd test suite files
 systemd-*/test/fuzz/fuzz-unit-file/*        systemd     *       *       unicode=SKIP

--- a/security/fc40
+++ b/security/fc40
@@ -68,5 +68,8 @@ dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.
 glibc-*/localedata/cmn_TW.UTF-8.in          glibc       *       *       unicode=SKIP
 glibc-*/libio/tst-widetext.input            glibc       *       *       unicode=SKIP
 
+# perl-Prima documentation contains RTL control characters on purpose
+Prima-*/Prima/Drawable/Glyphs.pm            perl-Prima  *       *       unicode=INFORM
+
 # systemd test suite files
 systemd-*/test/fuzz/fuzz-unit-file/*        systemd     *       *       unicode=SKIP


### PR DESCRIPTION
There are right-to-left Unicode control characters used on purpose in a documentation:

    =for latex-makedoc cut

       use Prima;
       $::application-> begin_paint;
       <202d>$::application-> text_shape_out('אפס123', 0,0);

       <202d>123ספא

    =for latex-makedoc cut

and rpminspect complains:

    A forbidden code point, 0x202D, was found in the
    Prima-1.70/Prima/Drawable/Glyphs.pm source file on line 999 at column 3.
    This source file is used by perl-Prima.spec.

Suppressing these Unicode checks was approved at
<https://lists.fedoraproject.org/archives/list/security@lists.fedoraproject.org/thread/JPLP5R4CGJD46KILRFK3S5GMX64IN7V4/>.