### PR TITLE
Update the Python path globs in the global ignore list

### DIFF
--- a/fedora.yaml
+++ b/fedora.yaml
@@ -219,9 +219,9 @@ ignore:
     #
     # This is an array of glob(3) compatible strings to match paths
     # to ignore.
-    - /usr/lib*/python?.?/site-packages/__pycache__
-    - /usr/lib*/python?.?/site-packages/*/*.pyc
-    - /usr/lib*/python?.?/site-packages/*/*.pyo
+    - /usr/lib*/python*.*/*/__pycache__
+    - /usr/lib*/python*.*/*/*.pyc
+    - /usr/lib*/python*.*/*/*.pyo
 
 security_path_prefix:
     # Optional: Path prefixes for files with security concerns.  This


### PR DESCRIPTION
Previously it was only catching Python X.Y versions, but when Y > 9 it would fail.  Also, __pycache__ subdirs started showing up elsewhere so make sure to capture those as well.