### PR TITLE
Exception in unicode test for clang

### DIFF
--- a/security/fc37
+++ b/security/fc37
@@ -70,3 +70,7 @@ glibc-*/libio/tst-widetext.input            glibc       *       *       unicode=
 
 # perl-Prima documentation contains RTL control characters on purpose
 Prima-*/Prima/Drawable/Glyphs.pm            perl-Prima  *       *       unicode=INFORM
+
+# clang
+# Ignore bidirectional unicode sequence documentation file
+clang-tools-extra-*.src/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  clang  *  *  unicode=SKIP

--- a/security/fc38
+++ b/security/fc38
@@ -70,3 +70,7 @@ glibc-*/libio/tst-widetext.input            glibc       *       *       unicode=
 
 # perl-Prima documentation contains RTL control characters on purpose
 Prima-*/Prima/Drawable/Glyphs.pm            perl-Prima  *       *       unicode=INFORM
+
+# clang
+# Ignore bidirectional unicode sequence documentation file
+clang-tools-extra-*.src/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  clang  *  *  unicode=SKIP

--- a/security/fc39
+++ b/security/fc39
@@ -73,3 +73,7 @@ Prima-*/Prima/Drawable/Glyphs.pm            perl-Prima  *       *       unicode=
 
 # systemd test suite files
 systemd-*/test/fuzz/fuzz-unit-file/*        systemd     *       *       unicode=SKIP
+
+# clang
+# Ignore bidirectional unicode sequence documentation file
+clang-tools-extra-*.src/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  clang  *  *  unicode=SKIP

--- a/security/fc40
+++ b/security/fc40
@@ -73,3 +73,7 @@ Prima-*/Prima/Drawable/Glyphs.pm            perl-Prima  *       *       unicode=
 
 # systemd test suite files
 systemd-*/test/fuzz/fuzz-unit-file/*        systemd     *       *       unicode=SKIP
+
+# clang
+# Ignore bidirectional unicode sequence documentation file
+clang-tools-extra-*.src/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  clang  *  *  unicode=SKIP


### PR DESCRIPTION
Ignore misleading-bidirectional.rst docfile which includes some bidi characters as part of a well-known example