### PR TITLE
Allow unicode in mumble translation files

### DIFF
--- a/security/fc37
+++ b/security/fc37
@@ -71,6 +71,9 @@ glibc-*/libio/tst-widetext.input            glibc       *       *       unicode=
 # perl-Prima documentation contains RTL control characters on purpose
 Prima-*/Prima/Drawable/Glyphs.pm            perl-Prima  *       *       unicode=INFORM
 
+# mumble has translation files that intentionally contain RTL control characters
+src/mumble/mumble_*.ts                      mumble      *       *       unicode=INFORM
+
 # clang
 # Ignore bidirectional unicode sequence documentation file
 clang-tools-extra-*.src/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  clang  *  *  unicode=SKIP

--- a/security/fc38
+++ b/security/fc38
@@ -71,6 +71,9 @@ glibc-*/libio/tst-widetext.input            glibc       *       *       unicode=
 # perl-Prima documentation contains RTL control characters on purpose
 Prima-*/Prima/Drawable/Glyphs.pm            perl-Prima  *       *       unicode=INFORM
 
+# mumble has translation files that intentionally contain RTL control characters
+src/mumble/mumble_*.ts                      mumble      *       *       unicode=INFORM
+
 # clang
 # Ignore bidirectional unicode sequence documentation file
 clang-tools-extra-*.src/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  clang  *  *  unicode=SKIP

--- a/security/fc39
+++ b/security/fc39
@@ -71,6 +71,9 @@ glibc-*/libio/tst-widetext.input            glibc       *       *       unicode=
 # perl-Prima documentation contains RTL control characters on purpose
 Prima-*/Prima/Drawable/Glyphs.pm            perl-Prima  *       *       unicode=INFORM
 
+# mumble has translation files that intentionally contain RTL control characters
+src/mumble/mumble_*.ts                      mumble      *       *       unicode=INFORM
+
 # systemd test suite files
 systemd-*/test/fuzz/fuzz-unit-file/*        systemd     *       *       unicode=SKIP
 

--- a/security/fc40
+++ b/security/fc40
@@ -71,6 +71,9 @@ glibc-*/libio/tst-widetext.input            glibc       *       *       unicode=
 # perl-Prima documentation contains RTL control characters on purpose
 Prima-*/Prima/Drawable/Glyphs.pm            perl-Prima  *       *       unicode=INFORM
 
+# mumble has translation files that intentionally contain RTL control characters
+src/mumble/mumble_*.ts                      mumble      *       *       unicode=INFORM
+
 # systemd test suite files
 systemd-*/test/fuzz/fuzz-unit-file/*        systemd     *       *       unicode=SKIP
 


### PR DESCRIPTION
There are intentional right-to-left unicode control characters in Mumble's translation files.  This results in "BAD" messages from rpminspect.

    A forbidden code point, 0x202B, was found in the
    mumble-1.4.287.src/src/mumble/mumble_he.ts source file on line 24 at
    column 21. This source file is used by mumble.spec.