### PR TITLE
add /var/tmp/tmt to addfile ignore list

### DIFF
--- a/fedora.yaml
+++ b/fedora.yaml
@@ -378,8 +378,8 @@ addedfiles:
     # for this inspection.  The format of this list is the same as the
     # global 'ignore' list.  The difference is the items specified
     # here will only be used during this inspection.
-    #ignore:
-    #    - /usr/lib*/libexample.so*
+    ignore:
+        - /var/tmp/tmt
 
 ownership:
     # Path prefixes where executable files live


### PR DESCRIPTION
tmt[1][2] uses /var/tmp/tmt with special permissions for tmt run workdirs, as defined in previous [PR#39](https://github.com/rpminspect/rpminspect-data-fedora/pull/39) , this fails addedfiles check during bodhi update ci tests[3]. This PR adds this path to ignored for addedfile check

[1] https://github.com/teemtee/tmt
[2] https://src.fedoraproject.org/rpms/tmt
[3] https://bodhi.fedoraproject.org/updates/FEDORA-2024-2bfb7dae5c