### PR TITLE
Add unicode exceptions for dotnet9.0

### DIFF
--- a/security/fc40
+++ b/security/fc40
@@ -56,13 +56,11 @@
 # dotnet
 # Ignore test data containing unicode codepoints
 dotnet-*/src/runtime/src/libraries/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_1?_0/IdnaTest_1?.txt dotnet*.0 * * unicode=INFORM
+dotnet-*/src/runtime/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/IdnMapping/Data/Unicode_1?_0/IdnaTest_1?.txt dotnet*.0 * * unicode=INFORM
 # Fixed in of .NET 7 and later with https://github.com/dotnet/aspnetcore/pull/38900
 dotnet-v6.*/src/aspnetcore/src/Http/Http/src/Features/FormOptions.cs dotnet6.0 * * unicode=INFORM
 dotnet-v6.*/src/aspnetcore/src/Http/WebUtilities/src/FormReader.cs dotnet6.0 * * unicode=INFORM
 dotnet-v6.*/src/aspnetcore/src/Http/WebUtilities/src/MultipartReader.cs dotnet6.0 * * unicode=INFORM
-# Ignore API-headers (reference assembly) in .NET 7 from older versions of .NET
-dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/6.0.0/ref/net6.0/Microsoft.AspNetCore.Http.xml dotnet7.0 * * unicode=INFORM
-dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/6.0.0/ref/net6.0/Microsoft.AspNetCore.WebUtilities.xml dotnet7.0 * * unicode=INFORM
 
 # glibc localedata template files and test files
 glibc-*/localedata/cmn_TW.UTF-8.in          glibc       *       *       unicode=SKIP

--- a/security/fc41
+++ b/security/fc41
@@ -56,13 +56,11 @@
 # dotnet
 # Ignore test data containing unicode codepoints
 dotnet-*/src/runtime/src/libraries/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_1?_0/IdnaTest_1?.txt dotnet*.0 * * unicode=INFORM
+dotnet-*/src/runtime/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/IdnMapping/Data/Unicode_1?_0/IdnaTest_1?.txt dotnet*.0 * * unicode=INFORM
 # Fixed in of .NET 7 and later with https://github.com/dotnet/aspnetcore/pull/38900
 dotnet-v6.*/src/aspnetcore/src/Http/Http/src/Features/FormOptions.cs dotnet6.0 * * unicode=INFORM
 dotnet-v6.*/src/aspnetcore/src/Http/WebUtilities/src/FormReader.cs dotnet6.0 * * unicode=INFORM
 dotnet-v6.*/src/aspnetcore/src/Http/WebUtilities/src/MultipartReader.cs dotnet6.0 * * unicode=INFORM
-# Ignore API-headers (reference assembly) in .NET 7 from older versions of .NET
-dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/6.0.0/ref/net6.0/Microsoft.AspNetCore.Http.xml dotnet7.0 * * unicode=INFORM
-dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/6.0.0/ref/net6.0/Microsoft.AspNetCore.WebUtilities.xml dotnet7.0 * * unicode=INFORM
 
 # glibc localedata template files and test files
 glibc-*/localedata/cmn_TW.UTF-8.in          glibc       *       *       unicode=SKIP

--- a/security/fc42
+++ b/security/fc42
@@ -56,13 +56,11 @@
 # dotnet
 # Ignore test data containing unicode codepoints
 dotnet-*/src/runtime/src/libraries/System.Globalization.Extensions/tests/IdnMapping/Data/Unicode_1?_0/IdnaTest_1?.txt dotnet*.0 * * unicode=INFORM
+dotnet-*/src/runtime/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/IdnMapping/Data/Unicode_1?_0/IdnaTest_1?.txt dotnet*.0 * * unicode=INFORM
 # Fixed in of .NET 7 and later with https://github.com/dotnet/aspnetcore/pull/38900
 dotnet-v6.*/src/aspnetcore/src/Http/Http/src/Features/FormOptions.cs dotnet6.0 * * unicode=INFORM
 dotnet-v6.*/src/aspnetcore/src/Http/WebUtilities/src/FormReader.cs dotnet6.0 * * unicode=INFORM
 dotnet-v6.*/src/aspnetcore/src/Http/WebUtilities/src/MultipartReader.cs dotnet6.0 * * unicode=INFORM
-# Ignore API-headers (reference assembly) in .NET 7 from older versions of .NET
-dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/6.0.0/ref/net6.0/Microsoft.AspNetCore.Http.xml dotnet7.0 * * unicode=INFORM
-dotnet-v7.*/src/source-build-reference-packages/src/targetPacks/ILsrc/microsoft.aspnetcore.app.ref/6.0.0/ref/net6.0/Microsoft.AspNetCore.WebUtilities.xml dotnet7.0 * * unicode=INFORM
 
 # glibc localedata template files and test files
 glibc-*/localedata/cmn_TW.UTF-8.in          glibc       *       *       unicode=SKIP


### PR DESCRIPTION
The .NET 9 unicode tests use some unicode codepoints (eg, 0x202E) that get flagged by rpminspect. These codepoints only appear in unicode tests, so are safe to ignore.

Also remove exceptions for now-EOL dotnet7.0.