### PR TITLE
Update unicode rule for clang in f41+

### DIFF
--- a/security/fc41
+++ b/security/fc41
@@ -77,4 +77,4 @@ systemd-*/test/fuzz/fuzz-unit-file/*        systemd     *       *       unicode=
 
 # clang
 # Ignore bidirectional unicode sequence documentation file
-clang-tools-extra-*.src/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  clang  *  *  unicode=SKIP
+llvm-project-*.src/clang-tools-extra/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  llvm  *  *  unicode=SKIP

--- a/security/fc42
+++ b/security/fc42
@@ -77,4 +77,4 @@ systemd-*/test/fuzz/fuzz-unit-file/*        systemd     *       *       unicode=
 
 # clang
 # Ignore bidirectional unicode sequence documentation file
-clang-tools-extra-*.src/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  clang  *  *  unicode=SKIP
+llvm-project-*.src/clang-tools-extra/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  llvm  *  *  unicode=SKIP


### PR DESCRIPTION
Starting LLVM 19 (f41 and newer) clang is merged with llvm. Hence the former rule is no longer valid as the package is now llvm and the path is slightly different.
https://fedoraproject.org/wiki/Changes/LLVM-19#Detailed_Description