### PR TITLE
Skip unicode checks for unicode testdata of Samba

### DIFF
--- a/security/fc41
+++ b/security/fc41
@@ -78,3 +78,7 @@ systemd-*/test/fuzz/fuzz-unit-file/*        systemd     *       *       unicode=
 # clang
 # Ignore bidirectional unicode sequence documentation file
 llvm-project-*.src/clang-tools-extra/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  llvm  *  *  unicode=SKIP
+
+# Samba
+# Testdata for unicode conversion tests
+samba-*/testdata/source-chars-bad.c  samba             *           *           unicode=SKIP

--- a/security/fc42
+++ b/security/fc42
@@ -78,3 +78,7 @@ systemd-*/test/fuzz/fuzz-unit-file/*        systemd     *       *       unicode=
 # clang
 # Ignore bidirectional unicode sequence documentation file
 llvm-project-*.src/clang-tools-extra/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  llvm  *  *  unicode=SKIP
+
+# Samba
+# Testdata for unicode conversion tests
+samba-*/testdata/source-chars-bad.c  samba             *           *           unicode=SKIP


### PR DESCRIPTION
We do unicode conversion in Samba especially UTF16 <-> UTF8 as Windows is UTF16. So we have testdata that everything works correctly. This should be marked to skip checking the test data.