### PR TITLE
Skip the unicode security check on some annobin and gcc tests

### DIFF
--- a/security/fc39
+++ b/security/fc39
@@ -80,3 +80,11 @@ systemd-*/test/fuzz/fuzz-unit-file/*        systemd     *       *       unicode=
 # clang
 # Ignore bidirectional unicode sequence documentation file
 clang-tools-extra-*.src/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  clang  *  *  unicode=SKIP
+
+# annobin
+# Skip unicode test for annobin's unicode tests
+annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
+
+# gcc
+# Skip unicode test for gcc's unicode tests
+gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP

--- a/security/fc40
+++ b/security/fc40
@@ -78,3 +78,11 @@ systemd-*/test/fuzz/fuzz-unit-file/*        systemd     *       *       unicode=
 # clang
 # Ignore bidirectional unicode sequence documentation file
 clang-tools-extra-*.src/docs/clang-tidy/checks/misc/misleading-bidirectional.rst  clang  *  *  unicode=SKIP
+
+# annobin
+# Skip unicode test for annobin's unicode tests
+annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
+
+# gcc
+# Skip unicode test for gcc's unicode tests
+gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP

--- a/security/fc41
+++ b/security/fc41
@@ -82,3 +82,11 @@ llvm-project-*.src/clang-tools-extra/docs/clang-tidy/checks/misc/misleading-bidi
 # Samba
 # Testdata for unicode conversion tests
 samba-*/testdata/source-chars-bad.c  samba             *           *           unicode=SKIP
+
+# annobin
+# Skip unicode test for annobin's unicode tests
+annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
+
+# gcc
+# Skip unicode test for gcc's unicode tests
+gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP

--- a/security/fc42
+++ b/security/fc42
@@ -82,3 +82,11 @@ llvm-project-*.src/clang-tools-extra/docs/clang-tidy/checks/misc/misleading-bidi
 # Samba
 # Testdata for unicode conversion tests
 samba-*/testdata/source-chars-bad.c  samba             *           *           unicode=SKIP
+
+# annobin
+# Skip unicode test for annobin's unicode tests
+annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
+
+# gcc
+# Skip unicode test for gcc's unicode tests
+gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP


### PR DESCRIPTION
The tests are in the test suite of the respective sources and are there to explicitly test CVE-2021-42574 mitigations. They are definitely false positives.