### PR TITLE
Remove cockpit-session

### DIFF
--- a/fileinfo/fc40
+++ b/fileinfo/fc40
@@ -20,7 +20,6 @@
 -rwsr-x---          root       disk       /usr/lib64/amanda/runtar
 -rwsr-xr-x          root       root       /usr/bin/at
 -rwsr-xr-x          root       root       /usr/libexec/clevis-luks-udisks2
--rwsr-x---          root       cockpit-wsinstance /usr/libexec/cockpit-session
 -rwsr-xr-x          root       root       /usr/bin/crontab
 -rwsr-x---          root       dbus       /usr/libexec/dbus-1/dbus-daemon-launch-helper
 -rwsr-xr-x          root       root       /usr/bin/fusermount

--- a/fileinfo/fc41
+++ b/fileinfo/fc41
@@ -20,7 +20,6 @@
 -rwsr-x---          root       disk       /usr/lib64/amanda/runtar
 -rwsr-xr-x          root       root       /usr/bin/at
 -rwsr-xr-x          root       root       /usr/libexec/clevis-luks-udisks2
--rwsr-x---          root       cockpit-wsinstance /usr/libexec/cockpit-session
 -rwsr-xr-x          root       root       /usr/bin/crontab
 -rwsr-x---          root       dbus       /usr/libexec/dbus-1/dbus-daemon-launch-helper
 -rwsr-xr-x          root       root       /usr/bin/fusermount

--- a/fileinfo/fc42
+++ b/fileinfo/fc42
@@ -20,7 +20,6 @@
 -rwsr-x---          root       disk       /usr/lib64/amanda/runtar
 -rwsr-xr-x          root       root       /usr/bin/at
 -rwsr-xr-x          root       root       /usr/libexec/clevis-luks-udisks2
--rwsr-x---          root       cockpit-wsinstance /usr/libexec/cockpit-session
 -rwsr-xr-x          root       root       /usr/bin/crontab
 -rwsr-x---          root       dbus       /usr/libexec/dbus-1/dbus-daemon-launch-helper
 -rwsr-xr-x          root       root       /usr/bin/fusermount


### PR DESCRIPTION
Cockpit 330 dropped the cockpit-session suid permissions and moved to systemd socket activation [1]. It is now a regular root:root 755 file, so drop the fileinfo entry.

[1] https://github.com/cockpit-project/cockpit/pull/16808

---

See the rpminspect failures in https://bodhi.fedoraproject.org/updates/FEDORA-2024-60684a3b16 and https://bodhi.fedoraproject.org/updates/FEDORA-2024-ba2375d278 . This PR should clear them up.