### PR TITLE
SSSD: a set of capabilities required by privileged binaries

### DIFF
--- a/capabilities/fc41
+++ b/capabilities/fc41
@@ -38,6 +38,6 @@ wireshark-cli             /usr/bin/dumpcap                cap_net_admin,cap_net_
 shadow-utils              /usr/bin/newuidmap              cap_setuid=ep
 shadow-utils              /usr/bin/newgidmap              cap_setgid=ep
 sssd-common               /usr/libexec/sssd/sssd_pam      cap_dac_read_search=p
-sssd-ipa                  /usr/libexec/sssd/selinux_child cap_chown,cap_dac_override,cap_setgid,cap_setuid=ep
-sssd-krb5-common          /usr/libexec/sssd/krb5_child    cap_chown,cap_dac_override,cap_setgid,cap_setuid=ep
-sssd-krb5-common          /usr/libexec/sssd/ldap_child    cap_chown,cap_dac_override,cap_setgid,cap_setuid=ep
+sssd-ipa                  /usr/libexec/sssd/selinux_child cap_setgid,cap_setuid=p
+sssd-krb5-common          /usr/libexec/sssd/krb5_child    cap_dac_read_search,cap_setgid,cap_setuid=p
+sssd-krb5-common          /usr/libexec/sssd/ldap_child    cap_dac_read_search=p

--- a/capabilities/fc42
+++ b/capabilities/fc42
@@ -38,6 +38,6 @@ wireshark-cli             /usr/bin/dumpcap                cap_net_admin,cap_net_
 shadow-utils              /usr/bin/newuidmap              cap_setuid=ep
 shadow-utils              /usr/bin/newgidmap              cap_setgid=ep
 sssd-common               /usr/libexec/sssd/sssd_pam      cap_dac_read_search=p
-sssd-ipa                  /usr/libexec/sssd/selinux_child cap_chown,cap_dac_override,cap_setgid,cap_setuid=ep
-sssd-krb5-common          /usr/libexec/sssd/krb5_child    cap_chown,cap_dac_override,cap_setgid,cap_setuid=ep
-sssd-krb5-common          /usr/libexec/sssd/ldap_child    cap_chown,cap_dac_override,cap_setgid,cap_setuid=ep
+sssd-ipa                  /usr/libexec/sssd/selinux_child cap_setgid,cap_setuid=p
+sssd-krb5-common          /usr/libexec/sssd/krb5_child    cap_dac_read_search,cap_setgid,cap_setuid=p
+sssd-krb5-common          /usr/libexec/sssd/ldap_child    cap_dac_read_search=p


### PR DESCRIPTION
was further reduced to:
```
krb5_child cap_dac_read_search,cap_setgid,cap_setuid=p
ldap_child cap_dac_read_search=p
selinux_child cap_setgid,cap_setuid=p
sssd_pam cap_dac_read_search=p
```

See https://github.com/SSSD/sssd/commit/84baae4b4ad02d486b5b2344f9202fb264da75f4