### PR TITLE
Skip the unicode security check on some binutils tests

### DIFF
--- a/security/fc41
+++ b/security/fc41
@@ -87,6 +87,10 @@ samba-*/testdata/source-chars-bad.c  samba             *           *           u
 # Skip unicode test for annobin's unicode tests
 annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
 
+# binutils
+# Skip unicode test for binutils's unicode tests
+binutils-*/gas/testsuite/gas/all/multibyte.s binutils   *       *       unicode=SKIP
+
 # gcc
 # Skip unicode test for gcc's unicode tests
 gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP

--- a/security/fc42
+++ b/security/fc42
@@ -87,6 +87,10 @@ samba-*/testdata/source-chars-bad.c  samba             *           *           u
 # Skip unicode test for annobin's unicode tests
 annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
 
+# binutils
+# Skip unicode test for binutils's unicode tests
+binutils-*/gas/testsuite/gas/all/multibyte.s binutils   *       *       unicode=SKIP
+
 # gcc
 # Skip unicode test for gcc's unicode tests
 gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP

--- a/security/fc43
+++ b/security/fc43
@@ -87,6 +87,10 @@ samba-*/testdata/source-chars-bad.c  samba             *           *           u
 # Skip unicode test for annobin's unicode tests
 annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
 
+# binutils
+# Skip unicode test for binutils's unicode tests
+binutils-*/gas/testsuite/gas/all/multibyte.s binutils   *       *       unicode=SKIP
+
 # gcc
 # Skip unicode test for gcc's unicode tests
 gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP

--- a/security/fc44
+++ b/security/fc44
@@ -87,6 +87,10 @@ samba-*/testdata/source-chars-bad.c  samba             *           *           u
 # Skip unicode test for annobin's unicode tests
 annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
 
+# binutils
+# Skip unicode test for binutils's unicode tests
+binutils-*/gas/testsuite/gas/all/multibyte.s binutils   *       *       unicode=SKIP
+
 # gcc
 # Skip unicode test for gcc's unicode tests
 gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP

--- a/security/fc45
+++ b/security/fc45
@@ -87,6 +87,10 @@ samba-*/testdata/source-chars-bad.c  samba             *           *           u
 # Skip unicode test for annobin's unicode tests
 annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
 
+# binutils
+# Skip unicode test for binutils's unicode tests
+binutils-*/gas/testsuite/gas/all/multibyte.s binutils   *       *       unicode=SKIP
+
 # gcc
 # Skip unicode test for gcc's unicode tests
 gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP

--- a/security/fc46
+++ b/security/fc46
@@ -87,6 +87,10 @@ samba-*/testdata/source-chars-bad.c  samba             *           *           u
 # Skip unicode test for annobin's unicode tests
 annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
 
+# binutils
+# Skip unicode test for binutils's unicode tests
+binutils-*/gas/testsuite/gas/all/multibyte.s binutils   *       *       unicode=SKIP
+
 # gcc
 # Skip unicode test for gcc's unicode tests
 gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP

--- a/security/fc47
+++ b/security/fc47
@@ -87,6 +87,10 @@ samba-*/testdata/source-chars-bad.c  samba             *           *           u
 # Skip unicode test for annobin's unicode tests
 annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
 
+# binutils
+# Skip unicode test for binutils's unicode tests
+binutils-*/gas/testsuite/gas/all/multibyte.s binutils   *       *       unicode=SKIP
+
 # gcc
 # Skip unicode test for gcc's unicode tests
 gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP

--- a/security/fc48
+++ b/security/fc48
@@ -87,6 +87,10 @@ samba-*/testdata/source-chars-bad.c  samba             *           *           u
 # Skip unicode test for annobin's unicode tests
 annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
 
+# binutils
+# Skip unicode test for binutils's unicode tests
+binutils-*/gas/testsuite/gas/all/multibyte.s binutils   *       *       unicode=SKIP
+
 # gcc
 # Skip unicode test for gcc's unicode tests
 gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP

--- a/security/fc49
+++ b/security/fc49
@@ -87,6 +87,10 @@ samba-*/testdata/source-chars-bad.c  samba             *           *           u
 # Skip unicode test for annobin's unicode tests
 annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
 
+# binutils
+# Skip unicode test for binutils's unicode tests
+binutils-*/gas/testsuite/gas/all/multibyte.s binutils   *       *       unicode=SKIP
+
 # gcc
 # Skip unicode test for gcc's unicode tests
 gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP

--- a/security/fc50
+++ b/security/fc50
@@ -87,6 +87,10 @@ samba-*/testdata/source-chars-bad.c  samba             *           *           u
 # Skip unicode test for annobin's unicode tests
 annobin-*/tests/trick-hello.s               annobin     *       *       unicode=SKIP
 
+# binutils
+# Skip unicode test for binutils's unicode tests
+binutils-*/gas/testsuite/gas/all/multibyte.s binutils   *       *       unicode=SKIP
+
 # gcc
 # Skip unicode test for gcc's unicode tests
 gcc-*/gcc/testsuite/c-c++-common/*Wbidi*.c  gcc         *       *       unicode=SKIP


### PR DESCRIPTION
The tests are part of the upstream test suite and are there to explicitly test CVE-2021-42574 mitigations. They are definitely false positives.